### PR TITLE
Updated dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,7 @@
         "php": ">=5.3.2",
         "aferrandini/phpqrcode": "1.0.1",
         "ticketpark/file-bundle": "~0.2",
-        "zendframework/zend-barcode": "~2.2",
-        "zendframework/zend-servicemanager": "2.3",
-        "zendframework/zend-validator": "2.3"
+        "zendframework/zend-barcode": "~2.3.6"
     },
 
     "require-dev": {


### PR DESCRIPTION
This PR sets `zendframework/zend-barcode` minimal version to 2.3.6 to fix security vulnerability (https://framework.zend.com/security/advisory/ZF2015-03)